### PR TITLE
token input

### DIFF
--- a/skupper/network/roles/skupper_link/tasks/execute.yml
+++ b/skupper/network/roles/skupper_link/tasks/execute.yml
@@ -29,12 +29,22 @@
   register: tokentemp
 
 # Saving secret content into the temporary
-- name: Saving token file
+- name: Saving token file from hostvar
   ansible.builtin.copy:
     content: "{{ hostvars[item.host]['generatedToken'] }}"
     dest: "{{ tokentemp.path }}"
     mode: '0644'
     remote_src: true
+  when: hostvars[item.host]['generatedToken'] is defined
+
+# Saving secret content into the temporary
+- name: Saving token file from var
+  ansible.builtin.copy:
+    content: "{{ tokens[item['host']]['generatedToken'] }}"
+    dest: "{{ tokentemp.path }}"
+    mode: '0644'
+    remote_src: true
+  when: tokens[item['host']]['generatedToken'] is defined
 
 # Add the temp file name to the link create command
 - name: Adding temporary file name to link create command

--- a/skupper/network/roles/skupper_link/tasks/validate.yml
+++ b/skupper/network/roles/skupper_link/tasks/validate.yml
@@ -7,4 +7,4 @@
 - name: Validating token exists for host
   ansible.builtin.fail:
     msg: "{{ item.host }} does not provide a generatedToken variable"
-  when: hostvars[item['host']]['generatedToken'] is not defined
+  when: hostvars[item['host']]['generatedToken'] is not defined and tokens[item['host']]['generatedToken'] is not defined


### PR DESCRIPTION
Have an option to specify the token as input instead of assuming all sites are managed with the same ansible inventory