### PR TITLE
token module does not fail if grant already redeemed

### DIFF
--- a/plugins/modules/token.py
+++ b/plugins/modules/token.py
@@ -253,10 +253,11 @@ class TokenModule:
             return ""
 
         if name:
-            if not has_condition(access_grant, "Ready") or \
-                    not self.can_be_redeemed(access_grant):
+            if not has_condition(access_grant, "Ready"):
                 raise RuntimeException(
                     msg="accessgrant '%s' cannot be redeemed" % (name))
+            if not self.can_be_redeemed(access_grant):
+                self.module.warn("accessgrant '{}' cannot be redeemed".format(name))
 
         access_token_name = "token-%s" % (
             access_grant.get("metadata").get("name"))
@@ -307,7 +308,7 @@ class TokenModule:
             if not has_condition(access_grant_it, "Ready"):
                 all_ready = False
                 continue
-            if not access_grant and self.can_be_redeemed(access_grant_it):
+            if not access_grant:
                 access_grant = access_grant_it
         return access_grant, all_ready
 

--- a/tests/unit/plugins/modules/test_token.py
+++ b/tests/unit/plugins/modules/test_token.py
@@ -346,9 +346,11 @@ class TestTokenModule(TestCase):
         my_grant['status']['redemptions'] = 1
         K8sClientMock.resources.append(my_grant)
         self.assertEqual(2, len(K8sClientMock.resources))
-        with self.assertRaises(AnsibleFailJson):
-            set_module_args({'name': 'my-grant'})
-            self.module.main()
+        with patch.object(basic.AnsibleModule, "warn") as mock_warn:
+            with self.assertRaises(AnsibleExitJson) as exit:
+                set_module_args({'name': 'my-grant'})
+                self.module.main()
+        mock_warn.assert_called_once_with("accessgrant 'my-grant' cannot be redeemed")
         self.assertEqual(2, len(K8sClientMock.resources))
 
     def test_kube_site_ready_grant_ready(self):


### PR DESCRIPTION
Module will show a warning, instead.
This avoid using failed_when clauses in playbooks to ignore errors when grant has already been redeemed,
and also helps avoid when clauses to check if a token was returned when using the resource module.