### PR TITLE
Increased retry count on token integration test

### DIFF
--- a/tests/integration/targets/token/tasks/workflow.yml
+++ b/tests/integration/targets/token/tasks/workflow.yml
@@ -56,7 +56,7 @@
       when: item.east.platform != "kubernetes"
     - name: Call backend service
       ansible.builtin.command: "{{ (item.west.platform == 'kubernetes') | ternary(kube_verify_command, nonkube_verify_command) }}"
-      retries: 10
+      retries: 20
       delay: 6
       register: _call_backend
       until: _call_backend.rc == 0


### PR DESCRIPTION
This helps the token integration test passing on
different environments where the initial 10 attempts are not enough.

Fixes #70.