### PR TITLE
Mount and uses the REGISTRY_AUTH_FILE when starting a system site

### DIFF
--- a/plugins/modules/system.py
+++ b/plugins/modules/system.py
@@ -248,6 +248,13 @@ class SystemModule:
         ]
         for source, dest in mounts(self.namespace, self.platform, self._engine).items():
             command.extend(["-v", "%s:%s:z" % (source, dest)])
+
+        defaultConfigJson = os.path.join(os.getenv("HOME"), ".docker", "config.json")
+        configJson = os.environ.get("REGISTRY_AUTH_FILE") or defaultConfigJson
+        if os.path.exists(configJson):
+            command.extend(["-v", "%s:%s:z" % (configJson, "/config.json")])
+            command.extend(["-e", "REGISTRY_AUTH_FILE=/config.json"])
+
         for var, val in env(self.platform, self._engine).items():
             command.extend(["-e", "%s=%s" % (var, val)])
         self.module.debug("SKUPPER_ROUTER_IMAGE: {}".format(os.environ.get("SKUPPER_ROUTER_IMAGE")))


### PR DESCRIPTION
Podman uses the $HOME/.docker/config.json by default, but when using the Docker socket endpoint, it is not using it, so we need to explicitly provide the config.json to be used.

This PR is also useful to podman sites, in case the config.json is not present in the default location, allowing users to pass the REGISTRY_AUTH_FILE environment variable when executing the system module.

Fixes #72.